### PR TITLE
Add possibility to use trust_proxy in peertube chart

### DIFF
--- a/peertube/templates/deployment.yaml
+++ b/peertube/templates/deployment.yaml
@@ -68,6 +68,8 @@ spec:
               value: {{ .Values.environment.signup  | quote }}
             - name: PEERTUBE_TRANSCODING_ENABLED
               value: {{ .Values.environment.transcoding | quote }}
+            - name: PEERTUBE_TRUST_PROXY
+              value: {{ .Values.environment.trustProxy | quote }}
           volumeMounts:
             - name: data
               mountPath: /data

--- a/peertube/values.yaml
+++ b/peertube/values.yaml
@@ -65,6 +65,8 @@ environment:
   admin: admin@domain.tld
   signup: false
   transcoding: false
+  # Add trustProxy as list eg: 127.0.0.1,192.168.1.0/24
+  trustProxy: "127.0.0.1"
 
 postgresql:
   postgresUser: peertube


### PR DESCRIPTION
Hello!

I have added to peertube docker image the possibility to use trust_proxy as env variable.
As kubernetes especially need this (because of ingress and kube-probe), I have made this PR, hope it could help :-)

Also, thank you for these charts! It really help me for my k8s cluster!

Thanks