### PR TITLE
Add persistent volume for /config to persist configuration through we…

### DIFF
--- a/peertube/templates/deployment.yaml
+++ b/peertube/templates/deployment.yaml
@@ -71,6 +71,8 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+            - name: config
+              mountPath: /config
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
@@ -86,10 +88,19 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
       volumes:
+{{- if .Values.persistence.data.enabled }}
         - name: data
-{{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ .Values.persistence.existingClaim }}
+            claimName: {{ .Values.persistence.data.existingClaim }}
 {{- else }}
-            emptyDir: {}
+        - name: data
+          emptyDir: {}
+{{- end }}
+{{- if .Values.persistence.config.enabled }}
+        - name: config
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.config.existingClaim }}
+{{- else }}
+        - name: config
+          emptyDir: {}
 {{- end }}

--- a/peertube/values.yaml
+++ b/peertube/values.yaml
@@ -45,8 +45,13 @@ tolerations: []
 affinity: {}
 
 persistence:
-  enabled: true
-  existingClaim: pvc-peertube
+  data:
+    enabled: false
+    existingClaim: pvc-peertube
+  config:
+    enabled: false
+    existingClaim: pvc-ptconfig
+
 
 environment:
   hostname: peertube.domain.fr


### PR DESCRIPTION
Hello!

I have added possibility to configure /config as a persistent volume, to be able to persist the configuratin done via the web interface
Without that, configuration is lost when redeploying/upgrading the chart, which could cause problem as more and more config are from the admin accounts :-)

Thanks!